### PR TITLE
Improve chatbot prompt for accurate responses

### DIFF
--- a/src/context/VoiceContext.tsx
+++ b/src/context/VoiceContext.tsx
@@ -148,7 +148,7 @@ export const useVoice = () => {
 
 export const VoiceProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   // State management
-  const [selectedLanguage, setSelectedLanguage] = useState('hi-IN');
+  const [selectedLanguage, setSelectedLanguage] = useState('en-IN');
   const [isRecording, setIsRecording] = useState(false);
   const [isListening, setIsListening] = useState(false);
   const [transcript, setTranscript] = useState('');
@@ -427,8 +427,8 @@ export const VoiceProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       let detectedLang = selectedLanguage;
       try {
         detectedLang = await detectLanguage(text);
-        // Only update if detection is confident and different
-        if (detectedLang !== selectedLanguage && detectedLang !== 'en-US') {
+        // Only update if detection is different
+        if (detectedLang !== selectedLanguage) {
           setSelectedLanguage(detectedLang);
         }
       } catch (langErr) {


### PR DESCRIPTION
Set default speech recognition to English (India) and enable dynamic language switching for all detected languages, including en-US.

This improves initial transcription reliability and ensures seamless multilingual detection during conversations, addressing the issue where the chatbot was not correctly understanding multiple languages.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c3104f1-139a-4454-b849-fd940b28c1ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c3104f1-139a-4454-b849-fd940b28c1ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

